### PR TITLE
add_message_on_group

### DIFF
--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -15,11 +15,9 @@
         = "Edit"
 
   .messages
-    .message
-      .message__upper-info
-        %p.massage__upper-talker ヨッシー
-        %p.massage__upper-date 2019/01/01(thu) 00:00:01
-      %p.message__text でっていう！
+    = render @messages
+    -# = render partial: 'message', collection: @messages
+
   .form
     = form_for [@group, @message] do |f|
       .input-box

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,0 +1,12 @@
+.message
+  .message__upper-info
+    .massage__upper-talker
+      = message.user.name
+    .massage__upper-date
+      = message.created_at.strftime("%Y/%m/%d %H:%M")
+
+  .message__text
+    - if message.content.present?
+      %p.message__text__content
+        = message.content
+    = image_tag message.image.url, class: 'message__text__image' if message.image.present?


### PR DESCRIPTION
(1)_main_chat.html.hamlの部分テンプレート化
※ 部分テンプレートのファイル名
　そこで使う変数が一致
　呼び出す部分テンプレートが同じフォルダ内
　なので、renderメソッドが省略化されている

(2) _message.html.hamlの追加
※ _main_chat.html.hamlの部分テンプレートファイル